### PR TITLE
Remove dummy architecture page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,6 +1,6 @@
 * xref:getting_started/getting_started.adoc[]
 ** xref:getting_started/create_rest_service.adoc[]
-* xref:architecture/architecture.adoc[]
+* Architecture
 ** xref:architecture/layered_architecture.adoc[]
 
 * Integration

--- a/modules/ROOT/pages/architecture/architecture.adoc
+++ b/modules/ROOT/pages/architecture/architecture.adoc
@@ -1,3 +1,0 @@
-= Architecture
-
-On micro architecture level devonfw is strictly aligned with the SEAguide TODO: Link -> remove article -> empty node in menu -> rename not to Architecture


### PR DESCRIPTION
Removed the architecture page and changed it to a static navigation title, that cannot be selected