### PR TITLE
Add workflow to detect errors in the antora files

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -1,0 +1,18 @@
+name: check-build
+
+on:
+  pull_request:
+    branches:    
+      - main
+
+jobs:
+  check-antora:
+    runs-on: ubuntu-latest
+    steps:                
+      - name: npm install for antora-cli
+        run: |
+          npm install
+      
+      - name: Build Antora 
+        run: | 
+          npm run build 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "npx antora ./antora-playbook.yml",
+    "build": "npx antora --log-failure-level=error ./antora-playbook.yml",
     "dev:server": "npx http-server build/site/ -c-1 -p 5000"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently errors in the antora build are detected earliest at the stage of the final build in the website. Actually, that's to late for a developer to respond.
The error on the page build should occur as early as possible during the PR.

Therefor, this PR commits a new workflow that just builds the website. Using the loglevel definition during the build leads to the build returning an exit status code in case any errors occur.